### PR TITLE
add release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() { echo "Usage: ./release.sh [commit_sha]"; exit 1; }
+
+set -e
+
+export COMMIT=$1
+
+if [ -z "$COMMIT" ]; then
+  usage
+fi
+
+gsutil cp gs://container-structure-test/builds/$COMMIT/container-structure-test gs://container-structure-test/latest/


### PR DESCRIPTION
run `./release.sh <commit_sha>` to copy the binary built at that commit to the `latest` directory in the GCS bucket.

cc @dlorenc 