### PR TITLE
Remove intermediate container/tar archive after creating

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ commandTests:
   excludedError: [".*Inst.*Security.* | .*Security.*Inst.*"]
 ```
 
+### Intermediate Artifacts
+Each command test run creates either a container (with the `docker` driver) or
+tar artifact (with the `tar` driver). By default, these are deleted after the
+test run finishes, but the `-save` flag can optionally be passed to keep
+these around. This would normally be used for debugging purposes.
+
 
 ## File Existence Tests
 File existence tests check to make sure a specific file (or directory) exist

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -31,13 +31,14 @@ import (
 )
 
 type DockerDriver struct {
-	cli           docker.Client
 	originalImage string
 	currentImage  string
+	cli           docker.Client
 	env           map[string]string
+	save          bool
 }
 
-func NewDockerDriver(image string) (Driver, error) {
+func NewDockerDriver(image string, save bool) (Driver, error) {
 	newCli, err := docker.NewClientFromEnv()
 	if err != nil {
 		return nil, err
@@ -47,6 +48,7 @@ func NewDockerDriver(image string) (Driver, error) {
 		currentImage:  image,
 		cli:           *newCli,
 		env:           nil,
+		save:          save,
 	}, nil
 }
 
@@ -257,10 +259,12 @@ func (d *DockerDriver) runAndCommit(t *testing.T, env []string, command []string
 		t.Errorf("Error committing container: %s", err.Error())
 	}
 
-	if err = d.cli.RemoveContainer(docker.RemoveContainerOptions{
-		ID: container.ID,
-	}); err != nil {
-		t.Logf("Error when removing container %s: %s", container.ID, err.Error())
+	if !d.save {
+		if err = d.cli.RemoveContainer(docker.RemoveContainerOptions{
+			ID: container.ID,
+		}); err != nil {
+			t.Logf("Error when removing container %s: %s", container.ID, err.Error())
+		}
 	}
 
 	d.currentImage = image.ID
@@ -308,10 +312,12 @@ func (d *DockerDriver) exec(t *testing.T, env []string, command []string) (strin
 		t.Errorf("Error retrieving container logs: %s", err.Error())
 	}
 
-	if err = d.cli.RemoveContainer(docker.RemoveContainerOptions{
-		ID: container.ID,
-	}); err != nil {
-		t.Logf("Error when removing container %s: %s", container.ID, err.Error())
+	if !d.save {
+		if err = d.cli.RemoveContainer(docker.RemoveContainerOptions{
+			ID: container.ID,
+		}); err != nil {
+			t.Logf("Error when removing container %s: %s", container.ID, err.Error())
+		}
 	}
 
 	return stdout.String(), stderr.String(), exitCode

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -257,6 +257,12 @@ func (d *DockerDriver) runAndCommit(t *testing.T, env []string, command []string
 		t.Errorf("Error committing container: %s", err.Error())
 	}
 
+	if err = d.cli.RemoveContainer(docker.RemoveContainerOptions{
+		ID: container.ID,
+	}); err != nil {
+		t.Logf("Error when removing container %s: %s", container.ID, err.Error())
+	}
+
 	d.currentImage = image.ID
 	return image.ID
 }
@@ -300,6 +306,12 @@ func (d *DockerDriver) exec(t *testing.T, env []string, command []string) (strin
 		Stderr:       true,
 	}); err != nil {
 		t.Errorf("Error retrieving container logs: %s", err.Error())
+	}
+
+	if err = d.cli.RemoveContainer(docker.RemoveContainerOptions{
+		ID: container.ID,
+	}); err != nil {
+		t.Logf("Error when removing container %s: %s", container.ID, err.Error())
 	}
 
 	return stdout.String(), stderr.String(), exitCode

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -47,7 +47,7 @@ type Driver interface {
 	Destroy()
 }
 
-func InitDriverImpl(driver string) func(string) (Driver, error) {
+func InitDriverImpl(driver string) func(string, bool) (Driver, error) {
 	switch driver {
 	// future drivers will be added here
 	case Docker:

--- a/drivers/tar_driver.go
+++ b/drivers/tar_driver.go
@@ -27,9 +27,10 @@ import (
 
 type TarDriver struct {
 	Image pkgutil.Image
+	Save  bool
 }
 
-func NewTarDriver(imageName string) (Driver, error) {
+func NewTarDriver(imageName string, save bool) (Driver, error) {
 	// if the image is in the local daemon, we should be using the docker driver anyway.
 	// only try remote.
 
@@ -55,7 +56,9 @@ func NewTarDriver(imageName string) (Driver, error) {
 }
 
 func (d *TarDriver) Destroy() {
-	pkgutil.CleanupImage(d.Image)
+	if !d.Save {
+		pkgutil.CleanupImage(d.Image)
+	}
 }
 
 func (d *TarDriver) Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand []unversioned.Command) {

--- a/structure_test.go
+++ b/structure_test.go
@@ -88,20 +88,21 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 	if !ok {
 		return nil, errors.New("Error encountered when type casting Structure Test interface")
 	}
-	tests.SetDriverImpl(driverImpl, imagePath)
+	tests.SetDriverImpl(driverImpl, imagePath, save)
 	return tests, nil
 }
 
 var configFiles arrayFlags
 
 var imagePath, driver string
-var pull bool
-var driverImpl func(string) (drivers.Driver, error)
+var save, pull bool
+var driverImpl func(string, bool) (drivers.Driver, error)
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&imagePath, "image", "", "path to test image")
 	flag.StringVar(&driver, "driver", "docker", "driver to use when running tests")
 	flag.BoolVar(&pull, "pull", false, "force a pull of the image before running tests")
+	flag.BoolVar(&save, "save", false, "preserve created containers after test run")
 
 	flag.Parse()
 	configFiles = flag.Args()

--- a/types.go
+++ b/types.go
@@ -23,7 +23,7 @@ import (
 )
 
 type StructureTest interface {
-	SetDriverImpl(func(string) (drivers.Driver, error), string)
+	SetDriverImpl(func(string, bool) (drivers.Driver, error), string, bool)
 	NewDriver() (drivers.Driver, error)
 	RunAll(t *testing.T) int
 }

--- a/types/v1/structure.go
+++ b/types/v1/structure.go
@@ -25,8 +25,9 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func(string) (drivers.Driver, error)
+	DriverImpl         func(string, bool) (drivers.Driver, error)
 	Image              string
+	Save               bool
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -35,12 +36,13 @@ type StructureTest struct {
 }
 
 func (st *StructureTest) NewDriver() (drivers.Driver, error) {
-	return st.DriverImpl(st.Image)
+	return st.DriverImpl(st.Image, st.Save)
 }
 
-func (st *StructureTest) SetDriverImpl(f func(string) (drivers.Driver, error), image string) {
+func (st *StructureTest) SetDriverImpl(f func(string, bool) (drivers.Driver, error), image string, save bool) {
 	st.DriverImpl = f
 	st.Image = image
+	st.Save = save
 }
 
 func (st *StructureTest) RunAll(t *testing.T) int {

--- a/types/v2/structure.go
+++ b/types/v2/structure.go
@@ -25,8 +25,9 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func(string) (drivers.Driver, error)
+	DriverImpl         func(string, bool) (drivers.Driver, error)
 	Image              string
+	Save               bool
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -36,12 +37,13 @@ type StructureTest struct {
 }
 
 func (st *StructureTest) NewDriver() (drivers.Driver, error) {
-	return st.DriverImpl(st.Image)
+	return st.DriverImpl(st.Image, st.Save)
 }
 
-func (st *StructureTest) SetDriverImpl(f func(string) (drivers.Driver, error), image string) {
+func (st *StructureTest) SetDriverImpl(f func(string, bool) (drivers.Driver, error), image string, save bool) {
 	st.DriverImpl = f
 	st.Image = image
+	st.Save = save
 }
 
 func (st *StructureTest) RunAll(t *testing.T) int {


### PR DESCRIPTION
This changes the default behavior to remove the intermediate artifact for each test after creating. Users can pass the `-save` flag to keep the intermediate container or tar archive around after the test run.

Fixes #16 