### PR TITLE
Add option to pull image before running tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     deps = [
         "//drivers:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/fsouza/go-dockerclient:go_default_library",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To use container structure tests to validate your containers, you need the follo
 - A container image to test against
 - A test .yaml or .json file with user defined structure tests to run inside of the specified container image
 
+Note that the test framework looks for the provided image in the local Docker
+daemon (if it is not provided as a tar). The `-pull` flag can optionally
+be provided to force a pull of a remote image before running the tests.
+
 ## Example Run
 An example run of the test framework:
 ```shell

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -22,6 +22,11 @@ import (
 	"github.com/GoogleCloudPlatform/container-structure-test/types/unversioned"
 )
 
+const (
+	Docker = "docker"
+	Tar    = "tar"
+)
+
 type Driver interface {
 	Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand []unversioned.Command)
 
@@ -45,9 +50,9 @@ type Driver interface {
 func InitDriverImpl(driver string) func(string) (Driver, error) {
 	switch driver {
 	// future drivers will be added here
-	case "docker":
+	case Docker:
 		return NewDockerDriver
-	case "tar":
+	case Tar:
 		return NewTarDriver
 	default:
 		return nil

--- a/structure_test.go
+++ b/structure_test.go
@@ -133,7 +133,7 @@ func TestMain(m *testing.M) {
 			Tag:          tag,
 			OutputStream: os.Stdout,
 		}, docker.AuthConfiguration{}); err != nil {
-			fmt.Println("Error pulling remote image %s: %s", imagePath, err.Error())
+			fmt.Printf("Error pulling remote image %s: %s", imagePath, err.Error())
 			os.Exit(1)
 		}
 	}

--- a/structure_test.go
+++ b/structure_test.go
@@ -119,11 +119,15 @@ func TestMain(m *testing.M) {
 	var err error
 
 	if pull {
+		if driver != drivers.Docker {
+			fmt.Println("Image pull not supported when not using Docker driver")
+			os.Exit(1)
+		}
 		var repository, tag string
 		parts := strings.Split(imagePath, ":")
 		repository = parts[0]
 		if len(parts) < 2 {
-			fmt.Println("Please provide specific tag for image.")
+			fmt.Println("Please provide specific tag for image")
 			os.Exit(1)
 		}
 		tag = parts[1]

--- a/structure_test.go
+++ b/structure_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/container-structure-test/drivers"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/ghodss/yaml"
 )
 
@@ -94,11 +95,13 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 var configFiles arrayFlags
 
 var imagePath, driver string
+var pull bool
 var driverImpl func(string) (drivers.Driver, error)
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&imagePath, "image", "", "path to test image")
 	flag.StringVar(&driver, "driver", "docker", "driver to use when running tests")
+	flag.BoolVar(&pull, "pull", false, "force a pull of the image before running tests")
 
 	flag.Parse()
 	configFiles = flag.Args()
@@ -114,6 +117,26 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
+
+	if pull {
+		var repository, tag string
+		parts := strings.Split(imagePath, ":")
+		repository = parts[0]
+		if len(parts) < 2 {
+			fmt.Println("Please provide specific tag for image.")
+			os.Exit(1)
+		}
+		tag = parts[1]
+		client, err := docker.NewClientFromEnv()
+		if err = client.PullImage(docker.PullImageOptions{
+			Repository:   repository,
+			Tag:          tag,
+			OutputStream: os.Stdout,
+		}, docker.AuthConfiguration{}); err != nil {
+			fmt.Println("Error pulling remote image %s: %s", imagePath, err.Error())
+			os.Exit(1)
+		}
+	}
 
 	driverImpl = drivers.InitDriverImpl(driver)
 	if driverImpl == nil {


### PR DESCRIPTION
This will allow users to pass the `-pull` flag to force a pull of an image before running tests.

Fixes #17 