### PR TITLE
Refactor driver interface to accept variable args

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/container-structure-test",
     deps = [
         "//drivers:go_default_library",
+        "//types/unversioned:go_default_library",
         "//types/v1:go_default_library",
         "//types/v2:go_default_library",
     ],

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -38,7 +38,7 @@ type DockerDriver struct {
 	save          bool
 }
 
-func NewDockerDriver(args unversioned.DriverConfig) (Driver, error) {
+func NewDockerDriver(args DriverConfig) (Driver, error) {
 	newCli, err := docker.NewClientFromEnv()
 	if err != nil {
 		return nil, err

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -39,8 +39,18 @@ type DockerDriver struct {
 }
 
 func NewDockerDriver(args []interface{}) (Driver, error) {
-	image := args[0].(string)
-	save := args[1].(bool)
+	if len(args) != 2 {
+		return nil, fmt.Errorf("Incorrect args passed to docker driver")
+	}
+	image, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("Got param of type %T for image but wanted string", args[0])
+	}
+	save, ok := args[1].(bool)
+	if !ok {
+		return nil, fmt.Errorf("Got param of type %T for save but wanted bool", args[0])
+	}
+
 	newCli, err := docker.NewClientFromEnv()
 	if err != nil {
 		return nil, err

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -38,7 +38,9 @@ type DockerDriver struct {
 	save          bool
 }
 
-func NewDockerDriver(image string, save bool) (Driver, error) {
+func NewDockerDriver(args []interface{}) (Driver, error) {
+	image := args[0].(string)
+	save := args[1].(bool)
 	newCli, err := docker.NewClientFromEnv()
 	if err != nil {
 		return nil, err

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -38,29 +38,17 @@ type DockerDriver struct {
 	save          bool
 }
 
-func NewDockerDriver(args []interface{}) (Driver, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("Incorrect args passed to docker driver")
-	}
-	image, ok := args[0].(string)
-	if !ok {
-		return nil, fmt.Errorf("Got param of type %T for image but wanted string", args[0])
-	}
-	save, ok := args[1].(bool)
-	if !ok {
-		return nil, fmt.Errorf("Got param of type %T for save but wanted bool", args[0])
-	}
-
+func NewDockerDriver(args unversioned.DriverConfig) (Driver, error) {
 	newCli, err := docker.NewClientFromEnv()
 	if err != nil {
 		return nil, err
 	}
 	return &DockerDriver{
-		originalImage: image,
-		currentImage:  image,
+		originalImage: args.Image,
+		currentImage:  args.Image,
 		cli:           *newCli,
 		env:           nil,
-		save:          save,
+		save:          args.Save,
 	}, nil
 }
 

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -27,6 +27,11 @@ const (
 	Tar    = "tar"
 )
 
+type DriverConfig struct {
+	Image string // used by Docker/Tar drivers
+	Save  bool   // used by Docker/Tar drivers
+}
+
 type Driver interface {
 	Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand []unversioned.Command)
 
@@ -47,7 +52,7 @@ type Driver interface {
 	Destroy()
 }
 
-func InitDriverImpl(driver string) func(unversioned.DriverConfig) (Driver, error) {
+func InitDriverImpl(driver string) func(DriverConfig) (Driver, error) {
 	switch driver {
 	// future drivers will be added here
 	case Docker:

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -47,7 +47,7 @@ type Driver interface {
 	Destroy()
 }
 
-func InitDriverImpl(driver string) func([]interface{}) (Driver, error) {
+func InitDriverImpl(driver string) func(unversioned.DriverConfig) (Driver, error) {
 	switch driver {
 	// future drivers will be added here
 	case Docker:

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -47,7 +47,7 @@ type Driver interface {
 	Destroy()
 }
 
-func InitDriverImpl(driver string) func(string, bool) (Driver, error) {
+func InitDriverImpl(driver string) func([]interface{}) (Driver, error) {
 	switch driver {
 	// future drivers will be added here
 	case Docker:

--- a/drivers/tar_driver.go
+++ b/drivers/tar_driver.go
@@ -30,9 +30,12 @@ type TarDriver struct {
 	Save  bool
 }
 
-func NewTarDriver(imageName string, save bool) (Driver, error) {
+func NewTarDriver(args []interface{}) (Driver, error) {
 	// if the image is in the local daemon, we should be using the docker driver anyway.
 	// only try remote.
+
+	imageName := args[0].(string)
+	save := args[1].(bool)
 
 	var prepper pkgutil.Prepper
 	if pkgutil.IsTar(imageName) {
@@ -52,6 +55,7 @@ func NewTarDriver(imageName string, save bool) (Driver, error) {
 	}
 	return &TarDriver{
 		Image: image,
+		Save:  save,
 	}, nil
 }
 

--- a/drivers/tar_driver.go
+++ b/drivers/tar_driver.go
@@ -15,6 +15,7 @@
 package drivers
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,12 +32,20 @@ type TarDriver struct {
 }
 
 func NewTarDriver(args []interface{}) (Driver, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("Incorrect args passed to tar driver")
+	}
+	imageName, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("Got param of type %T for imageName but wanted string", args[0])
+	}
+	save, ok := args[1].(bool)
+	if !ok {
+		return nil, fmt.Errorf("Got param of type %T for save but wanted bool", args[0])
+	}
+
 	// if the image is in the local daemon, we should be using the docker driver anyway.
 	// only try remote.
-
-	imageName := args[0].(string)
-	save := args[1].(bool)
-
 	var prepper pkgutil.Prepper
 	if pkgutil.IsTar(imageName) {
 		prepper = pkgutil.TarPrepper{

--- a/drivers/tar_driver.go
+++ b/drivers/tar_driver.go
@@ -30,7 +30,7 @@ type TarDriver struct {
 	Save  bool
 }
 
-func NewTarDriver(args unversioned.DriverConfig) (Driver, error) {
+func NewTarDriver(args DriverConfig) (Driver, error) {
 	// if the image is in the local daemon, we should be using the docker driver anyway.
 	// only try remote.
 	var prepper pkgutil.Prepper

--- a/drivers/tar_driver.go
+++ b/drivers/tar_driver.go
@@ -15,7 +15,6 @@
 package drivers
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,22 +30,11 @@ type TarDriver struct {
 	Save  bool
 }
 
-func NewTarDriver(args []interface{}) (Driver, error) {
-	if len(args) != 2 {
-		return nil, fmt.Errorf("Incorrect args passed to tar driver")
-	}
-	imageName, ok := args[0].(string)
-	if !ok {
-		return nil, fmt.Errorf("Got param of type %T for imageName but wanted string", args[0])
-	}
-	save, ok := args[1].(bool)
-	if !ok {
-		return nil, fmt.Errorf("Got param of type %T for save but wanted bool", args[0])
-	}
-
+func NewTarDriver(args unversioned.DriverConfig) (Driver, error) {
 	// if the image is in the local daemon, we should be using the docker driver anyway.
 	// only try remote.
 	var prepper pkgutil.Prepper
+	imageName := args.Image
 	if pkgutil.IsTar(imageName) {
 		prepper = pkgutil.TarPrepper{
 			Source: imageName,
@@ -64,7 +52,7 @@ func NewTarDriver(args []interface{}) (Driver, error) {
 	}
 	return &TarDriver{
 		Image: image,
-		Save:  save,
+		Save:  args.Save,
 	}, nil
 }
 

--- a/structure_test.go
+++ b/structure_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/GoogleCloudPlatform/container-structure-test/types/unversioned"
 	"io/ioutil"
 	"log"
 	"os"
@@ -97,8 +96,8 @@ var configFiles arrayFlags
 
 var imagePath, driver string
 var save, pull bool
-var driverImpl func(unversioned.DriverConfig) (drivers.Driver, error)
-var args *unversioned.DriverConfig
+var driverImpl func(drivers.DriverConfig) (drivers.Driver, error)
+var args *drivers.DriverConfig
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&imagePath, "image", "", "path to test image")
@@ -113,7 +112,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("Please supply path to image or tarball to test against")
 		os.Exit(1)
 	}
-	args = &unversioned.DriverConfig{
+	args = &drivers.DriverConfig{
 		Image: imagePath,
 		Save:  save,
 	}

--- a/structure_test.go
+++ b/structure_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/GoogleCloudPlatform/container-structure-test/types/unversioned"
 	"io/ioutil"
 	"log"
 	"os"
@@ -88,7 +89,7 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 	if !ok {
 		return nil, errors.New("Error encountered when type casting Structure Test interface")
 	}
-	tests.SetDriverImpl(driverImpl, args)
+	tests.SetDriverImpl(driverImpl, *args)
 	return tests, nil
 }
 
@@ -96,8 +97,8 @@ var configFiles arrayFlags
 
 var imagePath, driver string
 var save, pull bool
-var driverImpl func([]interface{}) (drivers.Driver, error)
-var args []interface{}
+var driverImpl func(unversioned.DriverConfig) (drivers.Driver, error)
+var args *unversioned.DriverConfig
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&imagePath, "image", "", "path to test image")
@@ -112,11 +113,10 @@ func TestMain(m *testing.M) {
 		fmt.Println("Please supply path to image or tarball to test against")
 		os.Exit(1)
 	}
-	// These args MUST be passed in this order; the docker/tar drivers expect them there,
-	// and will not be instantiated correctly if they are changed
-	args = make([]interface{}, 2)
-	args[0] = imagePath
-	args[1] = save
+	args = &unversioned.DriverConfig{
+		Image: imagePath,
+		Save:  save,
+	}
 
 	if len(configFiles) == 0 {
 		fmt.Println("Please provide at least one test config file")

--- a/structure_test.go
+++ b/structure_test.go
@@ -88,7 +88,7 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 	if !ok {
 		return nil, errors.New("Error encountered when type casting Structure Test interface")
 	}
-	tests.SetDriverImpl(driverImpl, imagePath, save)
+	tests.SetDriverImpl(driverImpl, args)
 	return tests, nil
 }
 
@@ -96,7 +96,8 @@ var configFiles arrayFlags
 
 var imagePath, driver string
 var save, pull bool
-var driverImpl func(string, bool) (drivers.Driver, error)
+var driverImpl func([]interface{}) (drivers.Driver, error)
+var args []interface{}
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&imagePath, "image", "", "path to test image")
@@ -111,6 +112,9 @@ func TestMain(m *testing.M) {
 		fmt.Println("Please supply path to image or tarball to test against")
 		os.Exit(1)
 	}
+	args = make([]interface{}, 2)
+	args[0] = imagePath
+	args[1] = save
 
 	if len(configFiles) == 0 {
 		fmt.Println("Please provide at least one test config file")

--- a/structure_test.go
+++ b/structure_test.go
@@ -112,6 +112,8 @@ func TestMain(m *testing.M) {
 		fmt.Println("Please supply path to image or tarball to test against")
 		os.Exit(1)
 	}
+	// These args MUST be passed in this order; the docker/tar drivers expect them there,
+	// and will not be instantiated correctly if they are changed
 	args = make([]interface{}, 2)
 	args[0] = imagePath
 	args[1] = save

--- a/types.go
+++ b/types.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/container-structure-test/drivers"
+	"github.com/GoogleCloudPlatform/container-structure-test/types/unversioned"
 	"github.com/GoogleCloudPlatform/container-structure-test/types/v1"
 	"github.com/GoogleCloudPlatform/container-structure-test/types/v2"
 )
 
 type StructureTest interface {
-	SetDriverImpl(func([]interface{}) (drivers.Driver, error), []interface{})
+	SetDriverImpl(func(unversioned.DriverConfig) (drivers.Driver, error), unversioned.DriverConfig)
 	NewDriver() (drivers.Driver, error)
 	RunAll(t *testing.T) int
 }

--- a/types.go
+++ b/types.go
@@ -18,13 +18,12 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/container-structure-test/drivers"
-	"github.com/GoogleCloudPlatform/container-structure-test/types/unversioned"
 	"github.com/GoogleCloudPlatform/container-structure-test/types/v1"
 	"github.com/GoogleCloudPlatform/container-structure-test/types/v2"
 )
 
 type StructureTest interface {
-	SetDriverImpl(func(unversioned.DriverConfig) (drivers.Driver, error), unversioned.DriverConfig)
+	SetDriverImpl(func(drivers.DriverConfig) (drivers.Driver, error), drivers.DriverConfig)
 	NewDriver() (drivers.Driver, error)
 	RunAll(t *testing.T) int
 }

--- a/types.go
+++ b/types.go
@@ -23,7 +23,7 @@ import (
 )
 
 type StructureTest interface {
-	SetDriverImpl(func(string, bool) (drivers.Driver, error), string, bool)
+	SetDriverImpl(func([]interface{}) (drivers.Driver, error), []interface{})
 	NewDriver() (drivers.Driver, error)
 	RunAll(t *testing.T) int
 }

--- a/types/unversioned/types.go
+++ b/types/unversioned/types.go
@@ -29,3 +29,9 @@ type Config struct {
 }
 
 type Command []string
+
+type DriverConfig struct {
+	Image    string
+	Save     bool
+	Metadata string
+}

--- a/types/unversioned/types.go
+++ b/types/unversioned/types.go
@@ -29,9 +29,3 @@ type Config struct {
 }
 
 type Command []string
-
-type DriverConfig struct {
-	Image    string
-	Save     bool
-	Metadata string
-}

--- a/types/v1/structure.go
+++ b/types/v1/structure.go
@@ -25,8 +25,8 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func(unversioned.DriverConfig) (drivers.Driver, error)
-	DriverArgs         unversioned.DriverConfig
+	DriverImpl         func(drivers.DriverConfig) (drivers.Driver, error)
+	DriverArgs         drivers.DriverConfig
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -38,7 +38,7 @@ func (st *StructureTest) NewDriver() (drivers.Driver, error) {
 	return st.DriverImpl(st.DriverArgs)
 }
 
-func (st *StructureTest) SetDriverImpl(f func(unversioned.DriverConfig) (drivers.Driver, error), args unversioned.DriverConfig) {
+func (st *StructureTest) SetDriverImpl(f func(drivers.DriverConfig) (drivers.Driver, error), args drivers.DriverConfig) {
 	st.DriverImpl = f
 	st.DriverArgs = args
 }

--- a/types/v1/structure.go
+++ b/types/v1/structure.go
@@ -25,9 +25,8 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func(string, bool) (drivers.Driver, error)
-	Image              string
-	Save               bool
+	DriverImpl         func([]interface{}) (drivers.Driver, error)
+	DriverArgs         []interface{}
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -36,13 +35,12 @@ type StructureTest struct {
 }
 
 func (st *StructureTest) NewDriver() (drivers.Driver, error) {
-	return st.DriverImpl(st.Image, st.Save)
+	return st.DriverImpl(st.DriverArgs)
 }
 
-func (st *StructureTest) SetDriverImpl(f func(string, bool) (drivers.Driver, error), image string, save bool) {
+func (st *StructureTest) SetDriverImpl(f func([]interface{}) (drivers.Driver, error), args []interface{}) {
 	st.DriverImpl = f
-	st.Image = image
-	st.Save = save
+	st.DriverArgs = args
 }
 
 func (st *StructureTest) RunAll(t *testing.T) int {

--- a/types/v1/structure.go
+++ b/types/v1/structure.go
@@ -25,8 +25,8 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func([]interface{}) (drivers.Driver, error)
-	DriverArgs         []interface{}
+	DriverImpl         func(unversioned.DriverConfig) (drivers.Driver, error)
+	DriverArgs         unversioned.DriverConfig
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -38,7 +38,7 @@ func (st *StructureTest) NewDriver() (drivers.Driver, error) {
 	return st.DriverImpl(st.DriverArgs)
 }
 
-func (st *StructureTest) SetDriverImpl(f func([]interface{}) (drivers.Driver, error), args []interface{}) {
+func (st *StructureTest) SetDriverImpl(f func(unversioned.DriverConfig) (drivers.Driver, error), args unversioned.DriverConfig) {
 	st.DriverImpl = f
 	st.DriverArgs = args
 }

--- a/types/v2/structure.go
+++ b/types/v2/structure.go
@@ -25,8 +25,8 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func(unversioned.DriverConfig) (drivers.Driver, error)
-	DriverArgs         unversioned.DriverConfig
+	DriverImpl         func(drivers.DriverConfig) (drivers.Driver, error)
+	DriverArgs         drivers.DriverConfig
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -39,7 +39,7 @@ func (st *StructureTest) NewDriver() (drivers.Driver, error) {
 	return st.DriverImpl(st.DriverArgs)
 }
 
-func (st *StructureTest) SetDriverImpl(f func(unversioned.DriverConfig) (drivers.Driver, error), args unversioned.DriverConfig) {
+func (st *StructureTest) SetDriverImpl(f func(drivers.DriverConfig) (drivers.Driver, error), args drivers.DriverConfig) {
 	st.DriverImpl = f
 	st.DriverArgs = args
 }

--- a/types/v2/structure.go
+++ b/types/v2/structure.go
@@ -25,8 +25,8 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func([]interface{}) (drivers.Driver, error)
-	DriverArgs         []interface{}
+	DriverImpl         func(unversioned.DriverConfig) (drivers.Driver, error)
+	DriverArgs         unversioned.DriverConfig
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -39,7 +39,7 @@ func (st *StructureTest) NewDriver() (drivers.Driver, error) {
 	return st.DriverImpl(st.DriverArgs)
 }
 
-func (st *StructureTest) SetDriverImpl(f func([]interface{}) (drivers.Driver, error), args []interface{}) {
+func (st *StructureTest) SetDriverImpl(f func(unversioned.DriverConfig) (drivers.Driver, error), args unversioned.DriverConfig) {
 	st.DriverImpl = f
 	st.DriverArgs = args
 }

--- a/types/v2/structure.go
+++ b/types/v2/structure.go
@@ -25,9 +25,8 @@ import (
 )
 
 type StructureTest struct {
-	DriverImpl         func(string, bool) (drivers.Driver, error)
-	Image              string
-	Save               bool
+	DriverImpl         func([]interface{}) (drivers.Driver, error)
+	DriverArgs         []interface{}
 	GlobalEnvVars      []unversioned.EnvVar
 	CommandTests       []CommandTest
 	FileExistenceTests []FileExistenceTest
@@ -37,13 +36,12 @@ type StructureTest struct {
 }
 
 func (st *StructureTest) NewDriver() (drivers.Driver, error) {
-	return st.DriverImpl(st.Image, st.Save)
+	return st.DriverImpl(st.DriverArgs)
 }
 
-func (st *StructureTest) SetDriverImpl(f func(string, bool) (drivers.Driver, error), image string, save bool) {
+func (st *StructureTest) SetDriverImpl(f func([]interface{}) (drivers.Driver, error), args []interface{}) {
 	st.DriverImpl = f
-	st.Image = image
-	st.Save = save
+	st.DriverArgs = args
 }
 
 func (st *StructureTest) RunAll(t *testing.T) int {


### PR DESCRIPTION
This is a precursor change that will allow us to add drivers that accept different parameters than `image` and `save`.

Also, fix a small bug where the `TarDriver` was ignoring the `save` boolean parameter.