### PR TITLE
Switch to go-yaml so we can use strict parsing.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,8 +44,8 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//drivers:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/fsouza/go-dockerclient:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
 

--- a/structure_test.go
+++ b/structure_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/container-structure-test/drivers"
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/ghodss/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 var totalTests int
@@ -61,7 +61,7 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 	case strings.HasSuffix(fp, ".json"):
 		unmarshal = json.Unmarshal
 	case strings.HasSuffix(fp, ".yaml"):
-		unmarshal = yaml.Unmarshal
+		unmarshal = yaml.UnmarshalStrict
 	default:
 		return nil, errors.New("Please provide valid JSON or YAML config file")
 	}


### PR DESCRIPTION
This will make the tests error if someone passes an invalid YAML, instead of silently ignore it.