### PR TITLE
Revert "Switch to go-yaml so we can use strict parsing. (#26)"

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,8 +44,8 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//drivers:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/fsouza/go-dockerclient:go_default_library",
-        "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
 

--- a/structure_test.go
+++ b/structure_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/container-structure-test/drivers"
 	docker "github.com/fsouza/go-dockerclient"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 var totalTests int
@@ -61,7 +61,7 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 	case strings.HasSuffix(fp, ".json"):
 		unmarshal = json.Unmarshal
 	case strings.HasSuffix(fp, ".yaml"):
-		unmarshal = yaml.UnmarshalStrict
+		unmarshal = yaml.Unmarshal
 	default:
 		return nil, errors.New("Please provide valid JSON or YAML config file")
 	}


### PR DESCRIPTION
This reverts commit 5a1465d8e4142e56aa6224a5ccd02834f942804b.

Looks like something with parsing is broken with this change, let's revert until we figure out why it doesn't work.