### PR TITLE
Switch to strict yaml parsing.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     deps = [
         "//drivers:go_default_library",
         "//vendor/github.com/fsouza/go-dockerclient:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
 

--- a/types.go
+++ b/types.go
@@ -36,7 +36,7 @@ var schemaVersions map[string]func() StructureTest = map[string]func() Structure
 }
 
 type SchemaVersion struct {
-	SchemaVersion string
+	SchemaVersion string `yaml:"schemaVersion"`
 }
 
 type Unmarshaller func([]byte, interface{}) error

--- a/types/v1/command.go
+++ b/types/v1/command.go
@@ -22,15 +22,15 @@ import (
 )
 
 type CommandTest struct {
-	Name           string
-	Setup          []unversioned.Command
-	EnvVars        []unversioned.EnvVar
-	ExitCode       int
-	Command        []string
-	ExpectedOutput []string
-	ExcludedOutput []string
-	ExpectedError  []string
-	ExcludedError  []string // excluded error from running command
+	Name           string                `yaml:"name"`
+	Setup          []unversioned.Command `yaml:"setup"`
+	EnvVars        []unversioned.EnvVar  `yaml:"envVars"`
+	ExitCode       int                   `yaml:"exitCode"`
+	Command        []string              `yaml:"command"`
+	ExpectedOutput []string              `yaml:"expectedOutput"`
+	ExcludedOutput []string              `yaml:"excludedOutput"`
+	ExpectedError  []string              `yaml:"expectedError"`
+	ExcludedError  []string              `yaml:"excludedError" ` // excluded error from running command
 }
 
 func validateCommandTest(t *testing.T, tt CommandTest) {

--- a/types/v1/file_content.go
+++ b/types/v1/file_content.go
@@ -20,10 +20,10 @@ import (
 )
 
 type FileContentTest struct {
-	Name             string   // name of test
-	Path             string   // file to check existence of
-	ExpectedContents []string // list of expected contents of file
-	ExcludedContents []string // list of excluded contents of file
+	Name             string   `yaml:"name"`             // name of test
+	Path             string   `yaml:"path"`             // file to check existence of
+	ExpectedContents []string `yaml:"expectedContents"` // list of expected contents of file
+	ExcludedContents []string `yaml:"excludedContents"` // list of excluded contents of file
 }
 
 func validateFileContentTest(t *testing.T, tt FileContentTest) {

--- a/types/v1/file_existence.go
+++ b/types/v1/file_existence.go
@@ -20,10 +20,10 @@ import (
 )
 
 type FileExistenceTest struct {
-	Name        string // name of test
-	Path        string // file to check existence of
-	ShouldExist bool   // whether or not the file should exist
-	Permissions string // expected Unix permission string of the file, e.g. drwxrwxrwx
+	Name        string `yaml:"name"`        // name of test
+	Path        string `yaml:"path"`        // file to check existence of
+	ShouldExist bool   `yaml:"shouldExist"` // whether or not the file should exist
+	Permissions string `yaml:"permissions"` // expected Unix permission string of the file, e.g. drwxrwxrwx
 }
 
 func validateFileExistenceTest(t *testing.T, tt FileExistenceTest) {

--- a/types/v1/licenses.go
+++ b/types/v1/licenses.go
@@ -23,10 +23,9 @@ import (
 	"github.com/GoogleCloudPlatform/container-structure-test/drivers"
 )
 
-// Not currently used, but leaving the possibility open
 type LicenseTest struct {
-	Debian bool
-	Files  []string
+	Debian bool     `yaml:"debian"`
+	Files  []string `yaml:"files"`
 }
 
 var (

--- a/types/v1/structure.go
+++ b/types/v1/structure.go
@@ -27,11 +27,11 @@ import (
 type StructureTest struct {
 	DriverImpl         func(drivers.DriverConfig) (drivers.Driver, error)
 	DriverArgs         drivers.DriverConfig
-	GlobalEnvVars      []unversioned.EnvVar
-	CommandTests       []CommandTest
-	FileExistenceTests []FileExistenceTest
-	FileContentTests   []FileContentTest
-	LicenseTests       []LicenseTest
+	GlobalEnvVars      []unversioned.EnvVar `yaml:"globalEnvVars"`
+	CommandTests       []CommandTest        `yaml:"commandTests"`
+	FileExistenceTests []FileExistenceTest  `yaml:"fileExistenceTests"`
+	FileContentTests   []FileContentTest    `yaml:"fileContentTest"`
+	LicenseTests       []LicenseTest        `yaml:"licenseTests"`
 }
 
 func (st *StructureTest) NewDriver() (drivers.Driver, error) {

--- a/types/v2/command.go
+++ b/types/v2/command.go
@@ -22,16 +22,16 @@ import (
 )
 
 type CommandTest struct {
-	Name           string
-	Setup          []unversioned.Command
-	EnvVars        []unversioned.EnvVar
-	ExitCode       int
-	Command        string
-	Args           []string
-	ExpectedOutput []string
-	ExcludedOutput []string
-	ExpectedError  []string
-	ExcludedError  []string // excluded error from running command
+	Name           string                `yaml:"name"`
+	Setup          []unversioned.Command `yaml:"setup"`
+	EnvVars        []unversioned.EnvVar  `yaml:"envVars"`
+	ExitCode       int                   `yaml:"exitCode"`
+	Command        string                `yaml:"command"`
+	Args           []string              `yaml:"args"`
+	ExpectedOutput []string              `yaml:"expectedOutput"`
+	ExcludedOutput []string              `yaml:"excludedOutput"`
+	ExpectedError  []string              `yaml:"expectedError"`
+	ExcludedError  []string              `yaml:"excludedError" ` // excluded error from running command
 }
 
 func validateCommandTest(t *testing.T, tt CommandTest) {

--- a/types/v2/file_content.go
+++ b/types/v2/file_content.go
@@ -20,10 +20,10 @@ import (
 )
 
 type FileContentTest struct {
-	Name             string   // name of test
-	Path             string   // file to check existence of
-	ExpectedContents []string // list of expected contents of file
-	ExcludedContents []string // list of excluded contents of file
+	Name             string   `yaml:"name"`             // name of test
+	Path             string   `yaml:"path"`             // file to check existence of
+	ExpectedContents []string `yaml:"expectedContents"` // list of expected contents of file
+	ExcludedContents []string `yaml:"excludedContents"` // list of excluded contents of file
 }
 
 func validateFileContentTest(t *testing.T, tt FileContentTest) {

--- a/types/v2/file_existence.go
+++ b/types/v2/file_existence.go
@@ -20,10 +20,10 @@ import (
 )
 
 type FileExistenceTest struct {
-	Name        string // name of test
-	Path        string // file to check existence of
-	ShouldExist bool   // whether or not the file should exist
-	Permissions string // expected Unix permission string of the file, e.g. drwxrwxrwx
+	Name        string `yaml:"name"`        // name of test
+	Path        string `yaml:"path"`        // file to check existence of
+	ShouldExist bool   `yaml:"shouldExist"` // whether or not the file should exist
+	Permissions string `yaml:"permissions"` // expected Unix permission string of the file, e.g. drwxrwxrwx
 }
 
 func validateFileExistenceTest(t *testing.T, tt FileExistenceTest) {

--- a/types/v2/licenses.go
+++ b/types/v2/licenses.go
@@ -25,8 +25,8 @@ import (
 
 // Not currently used, but leaving the possibility open
 type LicenseTest struct {
-	Debian bool
-	Files  []string
+	Debian bool     `yaml:"debian"`
+	Files  []string `yaml:"files"`
 }
 
 var (

--- a/types/v2/metadata.go
+++ b/types/v2/metadata.go
@@ -21,12 +21,12 @@ import (
 )
 
 type MetadataTest struct {
-	Env          []unversioned.EnvVar
-	ExposedPorts []string
-	Entrypoint   *[]string
-	Cmd          *[]string
-	Workdir      string
-	Volumes      []string
+	Env          []unversioned.EnvVar `yaml:"env"`
+	ExposedPorts []string             `yaml:"exposedPorts"`
+	Entrypoint   *[]string            `yaml:"entrypoint"`
+	Cmd          *[]string            `yaml:"cmd"`
+	Workdir      string               `yaml:"workdir"`
+	Volumes      []string             `yaml:"volumes"`
 }
 
 func (mt MetadataTest) LogName() string {

--- a/types/v2/structure.go
+++ b/types/v2/structure.go
@@ -27,12 +27,12 @@ import (
 type StructureTest struct {
 	DriverImpl         func(drivers.DriverConfig) (drivers.Driver, error)
 	DriverArgs         drivers.DriverConfig
-	GlobalEnvVars      []unversioned.EnvVar
-	CommandTests       []CommandTest
-	FileExistenceTests []FileExistenceTest
-	FileContentTests   []FileContentTest
-	MetadataTest       MetadataTest
-	LicenseTests       []LicenseTest
+	GlobalEnvVars      []unversioned.EnvVar `yaml:"globalEnvVars"`
+	CommandTests       []CommandTest        `yaml:"commandTests"`
+	FileExistenceTests []FileExistenceTest  `yaml:"fileExistenceTests"`
+	FileContentTests   []FileContentTest    `yaml:"fileContentTest"`
+	MetadataTest       MetadataTest         `yaml:"metadataTest"`
+	LicenseTests       []LicenseTest        `yaml:"licenseTests"`
 }
 
 func (st *StructureTest) NewDriver() (drivers.Driver, error) {


### PR DESCRIPTION
It looks like the big difference is that go-yaml defaults to fully
lower-cased field names, not camel-cased.