### PR TITLE
Add host driver

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     importpath = "github.com/GoogleCloudPlatform/container-structure-test",
     deps = [
         "//drivers:go_default_library",
+        "//utils:go_default_library",
         "//vendor/github.com/fsouza/go-dockerclient:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/container-structure-test",
     deps = [
         "//drivers:go_default_library",
+        "//types/unversioned:go_default_library",
         "//types/v1:go_default_library",
         "//types/v2:go_default_library",
     ],

--- a/drivers/BUILD.bazel
+++ b/drivers/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "docker_driver.go",
         "driver.go",
         "tar_driver.go",
+        "host_driver.go"
     ],
     importpath = "github.com/GoogleCloudPlatform/container-structure-test/drivers",
     visibility = ["//visibility:public"],

--- a/drivers/docker_driver.go
+++ b/drivers/docker_driver.go
@@ -56,11 +56,16 @@ func (d *DockerDriver) Destroy() {
 	// noop
 }
 
-func (d *DockerDriver) Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommands []unversioned.Command) {
+func (d *DockerDriver) Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommands [][]string) {
 	env := d.processEnvVars(t, envVars)
 	for _, cmd := range fullCommands {
 		d.currentImage = d.runAndCommit(t, env, cmd)
 	}
+}
+
+func (d *DockerDriver) Teardown(t *testing.T, envVars []unversioned.EnvVar, fullCommands [][]string) {
+	// since we create a new driver for each test, skip teardown commands
+	t.Logf("Docker driver does not support teardown commands, since each test gets a new driver. Skipping commands")
 }
 
 func (d *DockerDriver) ProcessCommand(t *testing.T, envVars []unversioned.EnvVar, fullCommand []string) (string, string, int) {

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -35,7 +35,10 @@ type DriverConfig struct {
 }
 
 type Driver interface {
-	Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand []unversioned.Command)
+	Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommands [][]string)
+
+	// Teardown is optional and is only used in the host driver
+	Teardown(t *testing.T, envVars []unversioned.EnvVar, fullCommands [][]string)
 
 	// given an array of command parts, construct a full command and execute it against the
 	// current environment. a list of environment variables can be passed to be set in the

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -25,6 +25,7 @@ import (
 const (
 	Docker = "docker"
 	Tar    = "tar"
+	Host   = "host"
 )
 
 type DriverConfig struct {
@@ -59,6 +60,8 @@ func InitDriverImpl(driver string) func(DriverConfig) (Driver, error) {
 		return NewDockerDriver
 	case Tar:
 		return NewTarDriver
+	case Host:
+		return NewHostDriver
 	default:
 		return nil
 	}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -29,8 +29,9 @@ const (
 )
 
 type DriverConfig struct {
-	Image string // used by Docker/Tar drivers
-	Save  bool   // used by Docker/Tar drivers
+	Image    string // used by Docker/Tar drivers
+	Save     bool   // used by Docker/Tar drivers
+	Metadata string // used by Host driver
 }
 
 type Driver interface {

--- a/drivers/host_driver.go
+++ b/drivers/host_driver.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drivers
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/container-structure-test/types/unversioned"
+)
+
+type HostDriver struct {
+	// Image pkgutil.Image
+	Root       string // defaults to /
+	ConfigPath string // path to image metadata config on host fs
+}
+
+func NewHostDriver(root string, ignore bool) (Driver, error) {
+	return &HostDriver{
+		Root: root,
+	}, nil
+}
+
+func (d *HostDriver) Destroy() {
+	// since we're running on the host, don't do anything
+}
+
+func (d *HostDriver) Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand []unversioned.Command) {
+	// TODO(nkubala): implement
+}
+
+func (d *HostDriver) ProcessCommand(t *testing.T, envVars []unversioned.EnvVar, fullCommand []string) (string, string, int) {
+	// TODO(nkubala): implement
+	return "", "", 0
+}
+
+func (d *HostDriver) StatFile(t *testing.T, path string) (os.FileInfo, error) {
+	return os.Stat(filepath.Join(d.Root, path))
+}
+
+func (d *HostDriver) ReadFile(t *testing.T, path string) ([]byte, error) {
+	return ioutil.ReadFile(filepath.Join(d.Root, path))
+}
+
+func (d *HostDriver) ReadDir(t *testing.T, path string) ([]os.FileInfo, error) {
+	return ioutil.ReadDir(filepath.Join(d.Root, path))
+}
+
+func (d *HostDriver) GetConfig(t *testing.T) (unversioned.Config, error) {
+	// docker provides these as maps (since they can be mapped in docker run commands)
+	// since this will never be the case when built through a dockerfile, we convert to list of strings
+	volumes := []string{}
+	for v := range d.Image.Config.Config.Volumes {
+		volumes = append(volumes, v)
+	}
+
+	ports := []string{}
+	for p := range d.Image.Config.Config.ExposedPorts {
+		// docker always appends the protocol to the port, so this is safe
+		ports = append(ports, strings.Split(p, "/")[0])
+	}
+
+	return unversioned.Config{
+		Env:          convertEnvToMap(d.Image.Config.Config.Env),
+		Entrypoint:   d.Image.Config.Config.Entrypoint,
+		Cmd:          d.Image.Config.Config.Cmd,
+		Volumes:      volumes,
+		Workdir:      d.Image.Config.Config.Workdir,
+		ExposedPorts: ports,
+	}, nil
+}

--- a/drivers/host_driver.go
+++ b/drivers/host_driver.go
@@ -29,7 +29,7 @@ type HostDriver struct {
 	ConfigPath string // path to image metadata config on host fs
 }
 
-func NewHostDriver(args unversioned.DriverConfig) (Driver, error) {
+func NewHostDriver(args DriverConfig) (Driver, error) {
 	return &HostDriver{
 		// Root: root,
 		ConfigPath: args.Metadata,

--- a/drivers/host_driver.go
+++ b/drivers/host_driver.go
@@ -65,9 +65,6 @@ func (d *HostDriver) Teardown(t *testing.T, envVars []unversioned.EnvVar, fullCo
 // given a list of environment variable key/value pairs, set these in the current environment.
 // also, keep track of the previous values of these vars to reset after test execution.
 func SetEnvVars(t *testing.T, vars []unversioned.EnvVar) []unversioned.EnvVar {
-	if vars == nil {
-		return nil
-	}
 	var originalVars []unversioned.EnvVar
 	for _, env_var := range vars {
 		originalVars = append(originalVars, unversioned.EnvVar{env_var.Key, os.Getenv(env_var.Key)})
@@ -79,9 +76,6 @@ func SetEnvVars(t *testing.T, vars []unversioned.EnvVar) []unversioned.EnvVar {
 }
 
 func ResetEnvVars(t *testing.T, vars []unversioned.EnvVar) {
-	if vars == nil {
-		return
-	}
 	for _, env_var := range vars {
 		var err error
 		if env_var.Value == "" {
@@ -109,7 +103,7 @@ func (d *HostDriver) ProcessCommand(t *testing.T, envVars []unversioned.EnvVar, 
 	exitCode := 0
 
 	if err := cmd.Start(); err != nil {
-		t.Errorf("error starting command: %v", err)
+		t.Fatalf("error starting command: %v", err)
 	}
 
 	if err := cmd.Wait(); err != nil {

--- a/drivers/host_driver.go
+++ b/drivers/host_driver.go
@@ -15,9 +15,9 @@
 package drivers
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,14 +25,14 @@ import (
 )
 
 type HostDriver struct {
-	// Image pkgutil.Image
-	Root       string // defaults to /
+	// Root       string // defaults to /
 	ConfigPath string // path to image metadata config on host fs
 }
 
-func NewHostDriver(root string, ignore bool) (Driver, error) {
+func NewHostDriver(args unversioned.DriverConfig) (Driver, error) {
 	return &HostDriver{
-		Root: root,
+		// Root: root,
+		ConfigPath: args.Metadata,
 	}, nil
 }
 
@@ -50,37 +50,48 @@ func (d *HostDriver) ProcessCommand(t *testing.T, envVars []unversioned.EnvVar, 
 }
 
 func (d *HostDriver) StatFile(t *testing.T, path string) (os.FileInfo, error) {
-	return os.Stat(filepath.Join(d.Root, path))
+	return os.Stat(path)
 }
 
 func (d *HostDriver) ReadFile(t *testing.T, path string) ([]byte, error) {
-	return ioutil.ReadFile(filepath.Join(d.Root, path))
+	return ioutil.ReadFile(path)
 }
 
 func (d *HostDriver) ReadDir(t *testing.T, path string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(filepath.Join(d.Root, path))
+	return ioutil.ReadDir(path)
 }
 
 func (d *HostDriver) GetConfig(t *testing.T) (unversioned.Config, error) {
-	// docker provides these as maps (since they can be mapped in docker run commands)
-	// since this will never be the case when built through a dockerfile, we convert to list of strings
+	file, err := ioutil.ReadFile(d.ConfigPath)
+	if err != nil {
+		t.Errorf("error retrieving config")
+		return unversioned.Config{}, err
+	}
+
+	var metadata unversioned.FlattenedMetadata
+
+	json.Unmarshal(file, &metadata)
+	config := metadata.Config
+
+	// // docker provides these as maps (since they can be mapped in docker run commands)
+	// // since this will never be the case when built through a dockerfile, we convert to list of strings
 	volumes := []string{}
-	for v := range d.Image.Config.Config.Volumes {
+	for v := range config.Volumes {
 		volumes = append(volumes, v)
 	}
 
 	ports := []string{}
-	for p := range d.Image.Config.Config.ExposedPorts {
+	for p := range config.ExposedPorts {
 		// docker always appends the protocol to the port, so this is safe
 		ports = append(ports, strings.Split(p, "/")[0])
 	}
 
 	return unversioned.Config{
-		Env:          convertEnvToMap(d.Image.Config.Config.Env),
-		Entrypoint:   d.Image.Config.Config.Entrypoint,
-		Cmd:          d.Image.Config.Config.Cmd,
+		Env:          convertEnvToMap(config.Env),
+		Entrypoint:   config.Entrypoint,
+		Cmd:          config.Cmd,
 		Volumes:      volumes,
-		Workdir:      d.Image.Config.Config.Workdir,
+		Workdir:      config.Workdir,
 		ExposedPorts: ports,
 	}, nil
 }

--- a/drivers/tar_driver.go
+++ b/drivers/tar_driver.go
@@ -62,8 +62,12 @@ func (d *TarDriver) Destroy() {
 	}
 }
 
-func (d *TarDriver) Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand []unversioned.Command) {
+func (d *TarDriver) Setup(t *testing.T, envVars []unversioned.EnvVar, fullCommand [][]string) {
 	// this driver is unable to process commands, inform user and fail.
+	t.Fatal("Tar driver is unable to process commands, please use a different driver")
+}
+
+func (d *TarDriver) Teardown(t *testing.T, envVars []unversioned.EnvVar, fullCommands [][]string) {
 	t.Fatal("Tar driver is unable to process commands, please use a different driver")
 }
 

--- a/structure_test.go
+++ b/structure_test.go
@@ -102,7 +102,7 @@ func Parse(t *testing.T, fp string) (StructureTest, error) {
 var configFiles arrayFlags
 
 var imagePath, driver, metadata string
-var save, pull bool
+var save, pull, force bool
 var driverImpl func(drivers.DriverConfig) (drivers.Driver, error)
 var args *drivers.DriverConfig
 
@@ -112,6 +112,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&metadata, "metadata", "", "path to image metadata file")
 	flag.BoolVar(&pull, "pull", false, "force a pull of the image before running tests")
 	flag.BoolVar(&save, "save", false, "preserve created containers after test run")
+	flag.BoolVar(&force, "force", false, "force run of host driver (without command line input)")
 
 	flag.Parse()
 	configFiles = flag.Args()
@@ -178,7 +179,7 @@ Be sure you know what you're doing before continuing!
 
 Continue? (y/n)`
 
-	if driver == drivers.Host && !utils.UserConfirmation(warnMessage) {
+	if driver == drivers.Host && !utils.UserConfirmation(warnMessage, force) {
 		os.Exit(1)
 	}
 

--- a/types/unversioned/types.go
+++ b/types/unversioned/types.go
@@ -29,3 +29,9 @@ type Config struct {
 }
 
 type Command []string
+
+type DriverConfig struct {
+	Image    string
+	Save     bool
+	Metadata string
+}

--- a/types/unversioned/types.go
+++ b/types/unversioned/types.go
@@ -40,5 +40,3 @@ type FlattenedConfig struct {
 type FlattenedMetadata struct {
 	Config FlattenedConfig `json:"config"`
 }
-
-type Command []string

--- a/types/unversioned/types.go
+++ b/types/unversioned/types.go
@@ -28,6 +28,19 @@ type Config struct {
 	ExposedPorts []string
 }
 
+type FlattenedConfig struct {
+	Env          []string            `json:"Env"`
+	Entrypoint   []string            `json:"Entrypoint"`
+	Cmd          []string            `json:"Cmd"`
+	Volumes      map[string]string   `json:"Volumes"`
+	Workdir      string              `json:"WorkingDir"`
+	ExposedPorts map[string][]string `json:"ExposedPorts"`
+}
+
+type FlattenedMetadata struct {
+	Config FlattenedConfig `json:"config"`
+}
+
 type Command []string
 
 type DriverConfig struct {

--- a/types/unversioned/types.go
+++ b/types/unversioned/types.go
@@ -42,9 +42,3 @@ type FlattenedMetadata struct {
 }
 
 type Command []string
-
-type DriverConfig struct {
-	Image    string
-	Save     bool
-	Metadata string
-}

--- a/types/v1/command.go
+++ b/types/v1/command.go
@@ -22,15 +22,16 @@ import (
 )
 
 type CommandTest struct {
-	Name           string                `yaml:"name"`
-	Setup          []unversioned.Command `yaml:"setup"`
-	EnvVars        []unversioned.EnvVar  `yaml:"envVars"`
-	ExitCode       int                   `yaml:"exitCode"`
-	Command        []string              `yaml:"command"`
-	ExpectedOutput []string              `yaml:"expectedOutput"`
-	ExcludedOutput []string              `yaml:"excludedOutput"`
-	ExpectedError  []string              `yaml:"expectedError"`
-	ExcludedError  []string              `yaml:"excludedError" ` // excluded error from running command
+	Name           string               `yaml:"name"`
+	Setup          [][]string           `yaml:"setup"`
+	Teardown       [][]string           `yaml:"teardown"`
+	EnvVars        []unversioned.EnvVar `yaml:"envVars"`
+	ExitCode       int                  `yaml:"exitCode"`
+	Command        []string             `yaml:"command"`
+	ExpectedOutput []string             `yaml:"expectedOutput"`
+	ExcludedOutput []string             `yaml:"excludedOutput"`
+	ExpectedError  []string             `yaml:"expectedError"`
+	ExcludedError  []string             `yaml:"excludedError" ` // excluded error from running command
 }
 
 func validateCommandTest(t *testing.T, tt CommandTest) {
@@ -44,6 +45,13 @@ func validateCommandTest(t *testing.T, tt CommandTest) {
 		for _, c := range tt.Setup {
 			if len(c) == 0 {
 				t.Fatalf("Error in setup command configuration encountered; please check formatting and remove all empty setup commands.")
+			}
+		}
+	}
+	if tt.Teardown != nil {
+		for _, c := range tt.Teardown {
+			if len(c) == 0 {
+				t.Fatalf("Error in teardown command configuration encountered; please check formatting and remove all empty teardown commands.")
 			}
 		}
 	}

--- a/types/v1/structure.go
+++ b/types/v1/structure.go
@@ -68,6 +68,7 @@ func (st *StructureTest) RunCommandTests(t *testing.T) int {
 			stdout, stderr, exitcode := driver.ProcessCommand(t, tt.EnvVars, tt.Command)
 
 			CheckOutput(t, tt, stdout, stderr, exitcode)
+			driver.Teardown(t, vars, tt.Teardown)
 			counter++
 		})
 	}

--- a/types/v2/command.go
+++ b/types/v2/command.go
@@ -22,16 +22,17 @@ import (
 )
 
 type CommandTest struct {
-	Name           string                `yaml:"name"`
-	Setup          []unversioned.Command `yaml:"setup"`
-	EnvVars        []unversioned.EnvVar  `yaml:"envVars"`
-	ExitCode       int                   `yaml:"exitCode"`
-	Command        string                `yaml:"command"`
-	Args           []string              `yaml:"args"`
-	ExpectedOutput []string              `yaml:"expectedOutput"`
-	ExcludedOutput []string              `yaml:"excludedOutput"`
-	ExpectedError  []string              `yaml:"expectedError"`
-	ExcludedError  []string              `yaml:"excludedError" ` // excluded error from running command
+	Name           string               `yaml:"name"`
+	Setup          [][]string           `yaml:"setup"`
+	Teardown       [][]string           `yaml:"teardown"`
+	EnvVars        []unversioned.EnvVar `yaml:"envVars"`
+	ExitCode       int                  `yaml:"exitCode"`
+	Command        string               `yaml:"command"`
+	Args           []string             `yaml:"args"`
+	ExpectedOutput []string             `yaml:"expectedOutput"`
+	ExcludedOutput []string             `yaml:"excludedOutput"`
+	ExpectedError  []string             `yaml:"expectedError"`
+	ExcludedError  []string             `yaml:"excludedError" ` // excluded error from running command
 }
 
 func validateCommandTest(t *testing.T, tt CommandTest) {
@@ -45,6 +46,13 @@ func validateCommandTest(t *testing.T, tt CommandTest) {
 		for _, c := range tt.Setup {
 			if len(c) == 0 {
 				t.Fatalf("Error in setup command configuration encountered; please check formatting and remove all empty setup commands.")
+			}
+		}
+	}
+	if tt.Teardown != nil {
+		for _, c := range tt.Teardown {
+			if len(c) == 0 {
+				t.Fatalf("Error in teardown command configuration encountered; please check formatting and remove all empty teardown commands.")
 			}
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 )
 
+var yesResponses = []string{"y", "Y", "yes", "Yes", "YES"}
+var noResponses = []string{"n", "N", "no", "No", "NO"}
+
 func CompileAndRunRegex(regex string, base string, t *testing.T, err string, shouldMatch bool) {
 	r, rErr := regexp.Compile(regex)
 	if rErr != nil {
@@ -45,8 +48,6 @@ func UserConfirmation(message string, force bool) bool {
 		// should maybe log something here
 		return false
 	}
-	yesResponses := []string{"y", "Y", "yes", "Yes", "YES"}
-	noResponses := []string{"n", "N", "no", "No", "NO"}
 	for _, response := range yesResponses {
 		if input == response {
 			return true

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -32,8 +32,12 @@ func CompileAndRunRegex(regex string, base string, t *testing.T, err string, sho
 }
 
 // adapted from https://gist.github.com/albrow/5882501
-func UserConfirmation(message string) bool {
+func UserConfirmation(message string, force bool) bool {
 	fmt.Println(message)
+	if force {
+		fmt.Println("Forcing test run!")
+		return true
+	}
 
 	var input string
 	_, err := fmt.Scanln(&input)
@@ -54,5 +58,5 @@ func UserConfirmation(message string) bool {
 		}
 	}
 	fmt.Println("Please type yes or no to continue or exit")
-	return UserConfirmation(message)
+	return UserConfirmation(message, force)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -28,4 +29,30 @@ func CompileAndRunRegex(regex string, base string, t *testing.T, err string, sho
 	if shouldMatch != r.MatchString(base) {
 		t.Errorf(err)
 	}
+}
+
+// adapted from https://gist.github.com/albrow/5882501
+func UserConfirmation(message string) bool {
+	fmt.Println(message)
+
+	var input string
+	_, err := fmt.Scanln(&input)
+	if err != nil {
+		// should maybe log something here
+		return false
+	}
+	yesResponses := []string{"y", "Y", "yes", "Yes", "YES"}
+	noResponses := []string{"n", "N", "no", "No", "NO"}
+	for _, response := range yesResponses {
+		if input == response {
+			return true
+		}
+	}
+	for _, response := range noResponses {
+		if input == response {
+			return false
+		}
+	}
+	fmt.Println("Please type yes or no to continue or exit")
+	return UserConfirmation(message)
 }


### PR DESCRIPTION
This PR implements a test driver for running directly on the host machine. This will allow us to create sandboxes based off of bazel "flattened" images and run the test binary directly inside them, in cases where it's not possible to use the existing drivers. In general, users should be discouraged from using this driver, as it can have potentially harmful side effects on a host machine (e.g. running a command test or setting an env var that has destructive effects).