### PR TITLE
Add support for running tests on private images

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_prefix")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 licenses(["notice"])
 
@@ -12,6 +13,20 @@ gazelle(
     build_tags = ["go1.7"],
     external = "vendored",
     prefix = "github.com/GoogleCloudPlatform/container-structure-test",
+)
+
+pkg_tar(
+    name = "cred_helper",
+    srcs = ["@docker_credential_gcr//:docker-credential-gcr"],
+    mode = "0555",
+    package_dir = "/usr/local/bin",
+)
+
+pkg_tar(
+    name = "default_creds",
+    srcs = [":config.json"],
+    mode = "0600",
+    package_dir = "/root/.docker",
 )
 
 sh_binary(
@@ -32,13 +47,21 @@ go_binary(
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
+    data = [
+        ":cred_helper.tar",
+        ":default_creds.tar",
+    ]
 )
 
 container_image(
     name = "structure_test_image",
     base = "@distroless_base//image",
     entrypoint = ["/structure_test"],
-    files = [":structure_test"],
+    files = [
+        ":structure_test",
+        ":cred_helper.tar",
+        ":default_creds.tar",
+    ],
 )
 
 go_prefix("github.com/GoogleCloudPlatform/container-structure-test")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,15 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 
+new_http_archive(
+    name = "docker_credential_gcr",
+    build_file_content = """package(default_visibility = ["//visibility:public"])
+exports_files(["docker-credential-gcr"])""",
+    sha256 = "3f02de988d69dc9c8d242b02cc10d4beb6bab151e31d63cb6af09dd604f75fce",
+    type = "tar.gz",
+    url = "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.4.3/docker-credential-gcr_linux_amd64-1.4.3.tar.gz",
+)
+
 load(
     "@io_bazel_rules_docker//docker:docker.bzl",
     "docker_repositories",

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+	"auths": {
+	},
+	"credHelpers": {
+		"appengine.gcr.io": "gcr",
+		"asia.gcr.io": "gcr",
+		"eu.gcr.io": "gcr",
+		"gcr.io": "gcr",
+		"gcr.kubernetes.io": "gcr",
+		"us.gcr.io": "gcr"
+	}
+}


### PR DESCRIPTION
This adds the docker-credential-gcr tool into the container-structure-test binary and image, which can be used to authenticate against private registries. 

Fixes #83 
Fixes #84 