### PR TITLE
Stream test results as they are run

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,6 +42,7 @@ go_binary(
     deps = [
         "//cmd:go_default_library",
         "//pkg/drivers:go_default_library",
+        "//pkg/output:go_default_library",
         "//pkg/utils:go_default_library",
         "//vendor/github.com/fsouza/go-dockerclient:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -93,13 +93,7 @@ func RunTests(out *output.OutWriter) bool {
 		if err != nil {
 			logrus.Fatalf("Error parsing config file: %s", err)
 		}
-		results := tests.RunAll(out)
-		for _, result := range results {
-			if !result.Pass {
-				pass = false
-			}
-		}
-		pass = pass && out.FinalResults(results)
+		pass = pass && out.FinalResults(tests.RunAll(out))
 	}
 	return pass
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/drivers"
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/output"
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/types"
-	"github.com/GoogleCloudPlatform/container-structure-test/pkg/types/unversioned"
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/utils"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/sirupsen/logrus"
@@ -52,12 +51,15 @@ var TestCmd = &cobra.Command{
 		return validateArgs()
 	},
 	Run: func(cmd *cobra.Command, _ []string) {
-		testResults := Run()
 		out := &output.OutWriter{
 			Verbose: verbose,
 			Quiet:   quiet,
 		}
-		os.Exit(out.OutputResults(testResults))
+		if pass := Run(out); pass {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
 	},
 }
 
@@ -83,19 +85,23 @@ func validateArgs() error {
 	return nil
 }
 
-func RunTests() []*unversioned.FullResult {
-	fullResults := []*unversioned.FullResult{}
+func RunTests(out *output.OutWriter) bool {
+	pass := true
 	for _, file := range configFiles {
+		out.Banner(file)
 		tests, err := Parse(file)
 		if err != nil {
 			logrus.Fatalf("Error parsing config file: %s", err)
 		}
-		fullResults = append(fullResults, &unversioned.FullResult{
-			FileName: file,
-			Results:  tests.RunAll(),
-		})
+		results := tests.RunAll(out)
+		for _, result := range results {
+			if !result.Pass {
+				pass = false
+			}
+		}
+		pass = pass && out.FinalResults(results)
 	}
-	return fullResults
+	return pass
 }
 
 func Parse(fp string) (types.StructureTest, error) {
@@ -144,7 +150,7 @@ func Parse(fp string) (types.StructureTest, error) {
 	return tests, nil
 }
 
-func Run() []*unversioned.FullResult {
+func Run(out *output.OutWriter) bool {
 	args = &drivers.DriverConfig{
 		Image:    imagePath,
 		Save:     save,
@@ -175,7 +181,7 @@ func Run() []*unversioned.FullResult {
 	}
 
 	if driver == drivers.Host && !utils.UserConfirmation(warnMessage, force) {
-		os.Exit(1)
+		return false
 	}
 
 	driverImpl = drivers.InitDriverImpl(driver)
@@ -186,7 +192,7 @@ func Run() []*unversioned.FullResult {
 		logrus.Fatal(err.Error())
 	}
 	logrus.Infof("Using driver %s\n", driver)
-	return RunTests()
+	return RunTests(out)
 }
 
 func init() {

--- a/pkg/output/BUILD.bazel
+++ b/pkg/output/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["output.go"],
+    srcs = ["output.go", "output_utils.go"],
     importpath = "github.com/GoogleCloudPlatform/container-structure-test/pkg/output",
     visibility = ["//visibility:public"],
     deps = ["//pkg/types/unversioned:go_default_library"],

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -28,16 +28,12 @@ type OutWriter struct {
 	Quiet   bool
 }
 
-func (o *OutWriter) OutputResult(result *types.TestResult) (int, int) {
+func (o *OutWriter) OutputResult(result *types.TestResult) {
 	// TODO(nkubala): use template
-	pass := 0
-	fail := 0
 	o.Printf("=== RUN: %s", result.Name)
 	if result.Pass {
-		pass++
 		o.green("--- PASS")
 	} else {
-		fail++
 		o.red("--- FAIL")
 	}
 	if o.Verbose {
@@ -51,7 +47,6 @@ func (o *OutWriter) OutputResult(result *types.TestResult) (int, int) {
 	for _, s := range result.Errors {
 		o.orange(fmt.Sprintf("Error: %s\n", s))
 	}
-	return pass, fail
 }
 
 func (o *OutWriter) Banner(filename string) {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -22,126 +22,71 @@ import (
 	types "github.com/GoogleCloudPlatform/container-structure-test/pkg/types/unversioned"
 )
 
-const (
-	RED         = "\033[0;31m"
-	GREEN       = "\033[0;32m"
-	LIGHT_GREEN = "\033[1;32m"
-	YELLOW      = "\033[1;33m"
-	ORANGE      = "\033[0;33m"
-	CYAN        = "\033[0;36m"
-	BLUE        = "\033[0;34m"
-	PURPLE      = "\033[0;35m"
-	NC          = "\033[0m" // No Color
-)
-
-// ANSI Color Escape Codes
-// Black        0;30     Dark Gray     1;30
-// Red          0;31     Light Red     1;31
-// Green        0;32     Light Green   1;32
-// Brown/Orange 0;33     Yellow        1;33
-// Blue         0;34     Light Blue    1;34
-// Purple       0;35     Light Purple  1;35
-// Cyan         0;36     Light Cyan    1;36
-
 type OutWriter struct {
 	Format  string // TODO(nkubala): implement JSON type
 	Verbose bool
 	Quiet   bool
 }
 
+func (o *OutWriter) OutputResult(result *types.TestResult) (int, int) {
+	// TODO(nkubala): use template
+	pass := 0
+	fail := 0
+	o.Printf("=== RUN: %s", result.Name)
+	if result.Pass {
+		pass++
+		o.green("--- PASS")
+	} else {
+		fail++
+		o.red("--- FAIL")
+	}
+	if o.Verbose {
+		if result.Stdout != "" {
+			o.blue(fmt.Sprintf("stdout: %s", result.Stdout))
+		}
+		if result.Stderr != "" {
+			o.blue(fmt.Sprintf("stderr: %s", result.Stderr))
+		}
+	}
+	for _, s := range result.Errors {
+		o.orange(fmt.Sprintf("Error: %s\n", s))
+	}
+	return pass, fail
+}
+
 func (o *OutWriter) Banner(filename string) {
 	fileStr := fmt.Sprintf("====== Test file: %s ======", filepath.Base(filename))
 	bannerStr := strings.Repeat("=", len(fileStr))
-	o.Purple(bannerStr)
-	o.Purple(fileStr)
-	o.Purple(bannerStr)
+	o.purple(bannerStr)
+	o.purple(fileStr)
+	o.purple(bannerStr)
 }
 
-func (o *OutWriter) OutputResults(fullResults []*types.FullResult) int {
+func (o *OutWriter) FinalResults(results []*types.TestResult) bool {
 	totalPass := 0
 	totalFail := 0
-	for _, fullResult := range fullResults {
-		o.Banner(fullResult.FileName)
-		pass := 0
-		fail := 0
-		if len(fullResult.Results) == 0 {
-			o.Red("No tests run! Check config file format.")
-			continue
+	for _, result := range results {
+		if result.Pass {
+			totalPass++
+		} else {
+			totalFail++
 		}
-		o.Cyan(fmt.Sprintf("Total tests run: %d\n", len(fullResult.Results)))
-		for _, result := range fullResult.Results {
-			// TODO(nkubala): use template
-			o.Printf("=== RUN: %s", result.Name)
-			if result.Pass {
-				pass++
-				o.Green("--- PASS")
-			} else {
-				fail++
-				o.Red("--- FAIL")
-			}
-			if o.Verbose {
-				if result.Stdout != "" {
-					o.Orange(fmt.Sprintf("stdout: %s", result.Stdout))
-				}
-				if result.Stderr != "" {
-					o.Orange(fmt.Sprintf("stderr: %s", result.Stderr))
-				}
-			}
-			for _, s := range result.Errors {
-				o.Yellow(fmt.Sprintf("Error: %s\n", s))
-			}
-		}
-		if pass > 0 {
-			o.Green(fmt.Sprintf("PASSES: %d", pass))
-		}
-		if fail > 0 {
-			o.Red(fmt.Sprintf("FAILURES: %d", fail))
-		}
-		totalPass += pass
-		totalFail += fail
 	}
+	totalTests := totalPass + totalFail
+	if totalTests == 0 {
+		o.red("No tests run! Check config file format.")
+		return false
+	}
+	o.Print("===============")
+	o.Print("=== RESULTS ===")
+	o.Print("===============")
+	o.lightGreen(fmt.Sprintf("Passes:      %d", totalPass))
+	o.lightRed(fmt.Sprintf("Failures:    %d", totalFail))
+	o.cyan(fmt.Sprintf("Total tests: %d", totalTests))
 	if totalFail > 0 {
-		o.Red("FAIL")
-		return 1
+		o.red("\nFAIL")
+		return false
 	}
-	o.Green("PASS")
-	return 0
-}
-
-func (o *OutWriter) Green(s string) {
-	o.Print(GREEN + s + NC)
-}
-
-func (o *OutWriter) LightGreen(s string) {
-	o.Print(LIGHT_GREEN + s + NC)
-}
-
-func (o *OutWriter) Yellow(s string) {
-	o.Print(YELLOW + s + NC)
-}
-
-func (o *OutWriter) Red(s string) {
-	o.Print(RED + s + NC)
-}
-
-func (o *OutWriter) Cyan(s string) {
-	o.Print(CYAN + s + NC)
-}
-
-func (o *OutWriter) Orange(s string) {
-	o.Print(ORANGE + s + NC)
-}
-
-func (o *OutWriter) Purple(s string) {
-	o.Print(PURPLE + s + NC)
-}
-
-func (o *OutWriter) Print(s string) {
-	if !o.Quiet {
-		fmt.Println(s)
-	}
-}
-
-func (o *OutWriter) Printf(s string, args ...interface{}) {
-	o.Print(fmt.Sprintf(s, args))
+	o.green("\nPASS")
+	return true
 }

--- a/pkg/output/output_utils.go
+++ b/pkg/output/output_utils.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+import (
+	"fmt"
+)
+
+const (
+	RED         = "\033[0;31m"
+	LIGHT_RED   = "\033[1;31m"
+	GREEN       = "\033[0;32m"
+	LIGHT_GREEN = "\033[1;32m"
+	YELLOW      = "\033[1;33m"
+	ORANGE      = "\033[0;33m"
+	CYAN        = "\033[0;36m"
+	BLUE        = "\033[0;34m"
+	PURPLE      = "\033[0;35m"
+	NC          = "\033[0m" // No Color
+)
+
+// ANSI Color Escape Codes
+// Black        0;30     Dark Gray     1;30
+// Red          0;31     Light Red     1;31
+// Green        0;32     Light Green   1;32
+// Brown/Orange 0;33     Yellow        1;33
+// Blue         0;34     Light Blue    1;34
+// Purple       0;35     Light Purple  1;35
+// Cyan         0;36     Light Cyan    1;36
+
+func (o *OutWriter) green(s string) {
+	o.Print(GREEN + s + NC)
+}
+
+func (o *OutWriter) blue(s string) {
+	o.Print(BLUE + s + NC)
+}
+
+func (o *OutWriter) lightGreen(s string) {
+	o.Print(LIGHT_GREEN + s + NC)
+}
+
+func (o *OutWriter) yellow(s string) {
+	o.Print(YELLOW + s + NC)
+}
+
+func (o *OutWriter) red(s string) {
+	o.Print(RED + s + NC)
+}
+
+func (o *OutWriter) lightRed(s string) {
+	o.Print(LIGHT_RED + s + NC)
+}
+
+func (o *OutWriter) cyan(s string) {
+	o.Print(CYAN + s + NC)
+}
+
+func (o *OutWriter) orange(s string) {
+	o.Print(ORANGE + s + NC)
+}
+
+func (o *OutWriter) purple(s string) {
+	o.Print(PURPLE + s + NC)
+}
+
+func (o *OutWriter) Print(s string) {
+	if !o.Quiet {
+		fmt.Println(s)
+	}
+}
+
+func (o *OutWriter) Printf(s string, args ...interface{}) {
+	o.Print(fmt.Sprintf(s, args))
+}

--- a/pkg/types/BUILD.bazel
+++ b/pkg/types/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/drivers:go_default_library",
+        "//pkg/output:go_default_library",        
         "//pkg/types/unversioned:go_default_library",
         "//pkg/types/v1:go_default_library",
         "//pkg/types/v2:go_default_library",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/drivers"
+	"github.com/GoogleCloudPlatform/container-structure-test/pkg/output"
 	types "github.com/GoogleCloudPlatform/container-structure-test/pkg/types/unversioned"
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/types/v1"
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/types/v2"
@@ -24,7 +25,7 @@ import (
 type StructureTest interface {
 	SetDriverImpl(func(drivers.DriverConfig) (drivers.Driver, error), drivers.DriverConfig)
 	NewDriver() (drivers.Driver, error)
-	RunAll() []*types.TestResult
+	RunAll(*output.OutWriter) []*types.TestResult
 }
 
 var SchemaVersions map[string]func() StructureTest = map[string]func() StructureTest{

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -45,11 +45,6 @@ type FlattenedMetadata struct {
 	Config FlattenedConfig `json:"config"`
 }
 
-type FullResult struct {
-	FileName string
-	Results  []*TestResult
-}
-
 type TestResult struct {
 	Name   string
 	Pass   bool

--- a/pkg/types/v1/BUILD.bazel
+++ b/pkg/types/v1/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/drivers:go_default_library",
+        "//pkg/output:go_default_library",        
         "//pkg/types/unversioned:go_default_library",
         "//pkg/utils:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",

--- a/pkg/types/v1/structure.go
+++ b/pkg/types/v1/structure.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/drivers"
+	"github.com/GoogleCloudPlatform/container-structure-test/pkg/output"
 	types "github.com/GoogleCloudPlatform/container-structure-test/pkg/types/unversioned"
 )
 
@@ -40,16 +41,16 @@ func (st *StructureTest) SetDriverImpl(f func(drivers.DriverConfig) (drivers.Dri
 	st.DriverArgs = args
 }
 
-func (st *StructureTest) RunAll() []*types.TestResult {
+func (st *StructureTest) RunAll(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
-	results = append(results, st.RunCommandTests()...)
-	results = append(results, st.RunFileExistenceTests()...)
-	results = append(results, st.RunFileContentTests()...)
-	results = append(results, st.RunLicenseTests()...)
+	results = append(results, st.RunCommandTests(o)...)
+	results = append(results, st.RunFileExistenceTests(o)...)
+	results = append(results, st.RunFileContentTests(o)...)
+	results = append(results, st.RunLicenseTests(o)...)
 	return results
 }
 
-func (st *StructureTest) RunCommandTests() []*types.TestResult {
+func (st *StructureTest) RunCommandTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
 	for _, test := range st.CommandTests {
 		if err := test.Validate(); err != nil {
@@ -72,12 +73,14 @@ func (st *StructureTest) RunCommandTests() []*types.TestResult {
 				logrus.Error(err.Error())
 			}
 		}()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }
 
-func (st *StructureTest) RunFileExistenceTests() []*types.TestResult {
+func (st *StructureTest) RunFileExistenceTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
 	for _, test := range st.FileExistenceTests {
 		if err := test.Validate(); err != nil {
@@ -89,14 +92,15 @@ func (st *StructureTest) RunFileExistenceTests() []*types.TestResult {
 			logrus.Fatalf(err.Error())
 		}
 		defer driver.Destroy()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }
 
-func (st *StructureTest) RunFileContentTests() []*types.TestResult {
+func (st *StructureTest) RunFileContentTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
-
 	for _, test := range st.FileContentTests {
 		if err := test.Validate(); err != nil {
 			logrus.Error(err.Error())
@@ -108,14 +112,15 @@ func (st *StructureTest) RunFileContentTests() []*types.TestResult {
 			logrus.Error(err.Error())
 		}
 		defer driver.Destroy()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }
 
-func (st *StructureTest) RunLicenseTests() []*types.TestResult {
+func (st *StructureTest) RunLicenseTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
-
 	for _, test := range st.LicenseTests {
 		driver, err := st.NewDriver()
 		if err != nil {
@@ -123,7 +128,9 @@ func (st *StructureTest) RunLicenseTests() []*types.TestResult {
 			continue
 		}
 		defer driver.Destroy()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }

--- a/pkg/types/v2/BUILD.bazel
+++ b/pkg/types/v2/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/drivers:go_default_library",
+        "//pkg/output:go_default_library",        
         "//pkg/types/unversioned:go_default_library",
         "//pkg/utils:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",

--- a/pkg/types/v2/structure.go
+++ b/pkg/types/v2/structure.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleCloudPlatform/container-structure-test/pkg/drivers"
+	"github.com/GoogleCloudPlatform/container-structure-test/pkg/output"
 	types "github.com/GoogleCloudPlatform/container-structure-test/pkg/types/unversioned"
 )
 
@@ -41,16 +42,16 @@ func (st *StructureTest) SetDriverImpl(f func(drivers.DriverConfig) (drivers.Dri
 	st.DriverArgs = args
 }
 
-func (st *StructureTest) RunAll() []*types.TestResult {
+func (st *StructureTest) RunAll(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
-	results = append(results, st.RunCommandTests()...)
-	results = append(results, st.RunFileExistenceTests()...)
-	results = append(results, st.RunFileContentTests()...)
-	results = append(results, st.RunLicenseTests()...)
+	results = append(results, st.RunCommandTests(o)...)
+	results = append(results, st.RunFileExistenceTests(o)...)
+	results = append(results, st.RunFileContentTests(o)...)
+	results = append(results, st.RunLicenseTests(o)...)
 	return results
 }
 
-func (st *StructureTest) RunCommandTests() []*types.TestResult {
+func (st *StructureTest) RunCommandTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
 	for _, test := range st.CommandTests {
 		if err := test.Validate(); err != nil {
@@ -73,12 +74,14 @@ func (st *StructureTest) RunCommandTests() []*types.TestResult {
 				logrus.Error(err.Error())
 			}
 		}()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }
 
-func (st *StructureTest) RunFileExistenceTests() []*types.TestResult {
+func (st *StructureTest) RunFileExistenceTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
 	for _, test := range st.FileExistenceTests {
 		if err := test.Validate(); err != nil {
@@ -90,12 +93,14 @@ func (st *StructureTest) RunFileExistenceTests() []*types.TestResult {
 			logrus.Fatalf(err.Error())
 		}
 		defer driver.Destroy()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }
 
-func (st *StructureTest) RunFileContentTests() []*types.TestResult {
+func (st *StructureTest) RunFileContentTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
 	for _, test := range st.FileContentTests {
 		if err := test.Validate(); err != nil {
@@ -108,21 +113,25 @@ func (st *StructureTest) RunFileContentTests() []*types.TestResult {
 			logrus.Error(err.Error())
 		}
 		defer driver.Destroy()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }
 
-func (st *StructureTest) RunMetadataTests() *types.TestResult {
+func (st *StructureTest) RunMetadataTests(o *output.OutWriter) *types.TestResult {
 	driver, err := st.NewDriver()
 	if err != nil {
 		logrus.Error(err.Error())
 	}
 	defer driver.Destroy()
-	return st.MetadataTest.Run(driver)
+	result := st.MetadataTest.Run(driver)
+	o.OutputResult(result)
+	return result
 }
 
-func (st *StructureTest) RunLicenseTests() []*types.TestResult {
+func (st *StructureTest) RunLicenseTests(o *output.OutWriter) []*types.TestResult {
 	results := make([]*types.TestResult, 0)
 	for _, test := range st.LicenseTests {
 		driver, err := st.NewDriver()
@@ -131,7 +140,9 @@ func (st *StructureTest) RunLicenseTests() []*types.TestResult {
 			continue
 		}
 		defer driver.Destroy()
-		results = append(results, test.Run(driver))
+		result := test.Run(driver)
+		results = append(results, result)
+		o.OutputResult(result)
 	}
 	return results
 }


### PR DESCRIPTION
This change makes the results of the tests stream out to the console as the tests are run, instead of waiting for all tests to finish running before outputting. This changes the signatures for all test-related methods to take in an `OutWriter`, and put the responsibility on the test methods themselves to write out their results.