### PR TITLE
Run metadata tests

### DIFF
--- a/pkg/types/v2/structure.go
+++ b/pkg/types/v2/structure.go
@@ -48,6 +48,7 @@ func (st *StructureTest) RunAll(o *output.OutWriter) []*types.TestResult {
 	results = append(results, st.RunFileExistenceTests(o)...)
 	results = append(results, st.RunFileContentTests(o)...)
 	results = append(results, st.RunLicenseTests(o)...)
+	results = append(results, st.RunMetadataTests(o))
 	return results
 }
 


### PR DESCRIPTION
This call got left out when I rewrote the framework a few weeks ago.

Fixes #97 